### PR TITLE
Allow choosing model via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# holst-chatbot
+# Holst Chatbot
+
+Simple example of a streaming chat interface using the OpenAI API.
+
+## Configuration
+
+Set the following environment variables:
+
+- `OPENAI_API_KEY` – your OpenAI API key.
+- `OPENAI_MODEL` – the model name to use (defaults to `gpt-4o-mini`).
+
+Run a server that handles POST requests to `/api/chat`.

--- a/api/chat.js
+++ b/api/chat.js
@@ -14,10 +14,12 @@ export default async function handler(req) {
   }
 
   const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  // Select model according to OPENAI_MODEL env var, fall back to gpt-4o-mini
+  const model = process.env.OPENAI_MODEL || "gpt-4o-mini";
 
   try {
     const completion = await openai.chat.completions.create({
-      model: "gpt-4o-mini",                    // при желании замените на другую модель
+      model,
       messages: [{ role: "user", content: message }],
       stream: true,
     });


### PR DESCRIPTION
## Summary
- enable model selection with `OPENAI_MODEL` environment variable
- document configuration options and usage

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687df4158194833297e2995384315ecd